### PR TITLE
If requested, display full mail addresses for TeamMailboxes (enabling cross-domain support)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "james-project"]
 	path = james-project
-	url = https://github.com/apache/james-project
-	branch = postgresql
+	url = https://github.com/giz-berlin/james-project
+	branch = postgresql_crossdomain

--- a/tmail-backend/apps/postgres/sample-configuration/imap.properties
+++ b/tmail-backend/apps/postgres/sample-configuration/imap.properties
@@ -1,0 +1,2 @@
+# Boolean. Optional, default to false. Whether full domain display is enabled for team mailboxes.
+imap.teamMailbox.fullDomain.enabled=false

--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailConfiguration.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailConfiguration.java
@@ -36,6 +36,7 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
                                          LinagoraServicesDiscoveryModuleChooserConfiguration linagoraServicesDiscoveryModuleChooserConfiguration,
                                          boolean jmapEnabled,
                                          boolean rlsEnabled,
+                                         boolean teamMailboxFullDomainEnabled,
                                          PropertiesProvider propertiesProvider,
                                          PostgresJamesConfiguration.EventBusImpl eventBusImpl) implements Configuration {
     public static class Builder {
@@ -50,6 +51,7 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
         private Optional<LinagoraServicesDiscoveryModuleChooserConfiguration> linagoraServicesDiscoveryModuleChooserConfiguration;
         private Optional<Boolean> jmapEnabled;
         private Optional<Boolean> rlsEnabled;
+        private Optional<Boolean> teamMailboxFullDomainEnabled;
         private Optional<PostgresJamesConfiguration.EventBusImpl> eventBusImpl;
 
         private Builder() {
@@ -64,6 +66,7 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
             linagoraServicesDiscoveryModuleChooserConfiguration = Optional.empty();
             jmapEnabled = Optional.empty();
             rlsEnabled = Optional.empty();
+            teamMailboxFullDomainEnabled = Optional.empty();
             eventBusImpl = Optional.empty();
         }
 
@@ -140,6 +143,11 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
             return this;
         }
 
+        public Builder teamMailboxFullDomainEnabled(Optional<Boolean> teamMailboxFullDomainEnabled) {
+            this.teamMailboxFullDomainEnabled = teamMailboxFullDomainEnabled;
+            return this;
+        }
+
         public Builder eventBusImpl(PostgresJamesConfiguration.EventBusImpl eventBusImpl) {
             this.eventBusImpl = Optional.of(eventBusImpl);
             return this;
@@ -190,6 +198,16 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
 
             boolean rlsEnabled = this.rlsEnabled.orElse(readRLSEnabledFromFile(propertiesProvider));
 
+            boolean teamMailboxFullDomainEnabled = this.teamMailboxFullDomainEnabled.orElseGet(() -> {
+                try {
+                    return propertiesProvider.getConfiguration("imap").getBoolean("imap.teamMailbox.fullDomain.enabled");
+                } catch (FileNotFoundException e) {
+                    return false;
+                } catch (ConfigurationException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
             PostgresJamesConfiguration.EventBusImpl eventBusImpl = this.eventBusImpl.orElseGet(() -> PostgresJamesConfiguration.EventBusImpl.from(propertiesProvider));
 
             return new PostgresTmailConfiguration(
@@ -204,6 +222,7 @@ public record PostgresTmailConfiguration(ConfigurationPath configurationPath, Ja
                 servicesDiscoveryModuleChooserConfiguration,
                 jmapEnabled,
                 rlsEnabled,
+                    teamMailboxFullDomainEnabled,
                 propertiesProvider,
                 eventBusImpl);
         }

--- a/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
+++ b/tmail-backend/apps/postgres/src/main/java/com/linagora/tmail/james/app/PostgresTmailServer.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
+import com.linagora.tmail.imap.TMailCrossDomainIMAPModule;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.james.ExtraProperties;
 import org.apache.james.GuiceJamesServer;
@@ -307,7 +308,7 @@ public class PostgresTmailServer {
             new PostgresTicketStoreModule(),
             new TasksHeathCheckModule(),
             chooseEventBusModules(configuration),
-            new TMailIMAPModule());
+            chooseIMAPModule(configuration));
 
     private static final Module SCANNING_QUOTA_SEARCH_MODULE = new AbstractModule() {
         @Override
@@ -411,6 +412,14 @@ public class PostgresTmailServer {
             return new JMAPEventBusModule();
         }
         return Modules.EMPTY_MODULE;
+    }
+
+    public static Module chooseIMAPModule(PostgresTmailConfiguration configuration) {
+        if (configuration.teamMailboxFullDomainEnabled()) {
+            return new TMailCrossDomainIMAPModule();
+        } else {
+            return new TMailIMAPModule();
+        }
     }
 
     private static List<Module> chooseFirebase(FirebaseModuleChooserConfiguration moduleChooserConfiguration) {

--- a/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/BlobStoreConfiguration.java
+++ b/tmail-backend/guice/blob-guice/src/main/java/com/linagora/tmail/blob/guice/BlobStoreConfiguration.java
@@ -199,7 +199,7 @@ public record BlobStoreConfiguration(BlobStoreImplName implementation,
 
         if (deduplicationEnabled) {
             return builder()
-                .implementation(BlobStoreImplName.S3)
+                .implementation(blobStoreImplName)
                 .secondaryS3BlobStore(parseS3BlobStoreConfiguration(configuration))
                 .enableCache(cacheEnabled)
                 .deduplication()
@@ -207,7 +207,7 @@ public record BlobStoreConfiguration(BlobStoreImplName implementation,
                 .enableSingleSave(singleSaveEnabled);
         } else {
             return builder()
-                .implementation(BlobStoreImplName.S3)
+                .implementation(blobStoreImplName)
                 .secondaryS3BlobStore(parseS3BlobStoreConfiguration(configuration))
                 .enableCache(cacheEnabled)
                 .passthrough()

--- a/tmail-backend/imap-extensions/src/main/java/com/linagora/tmail/imap/TMailCrossDomainIMAPModule.java
+++ b/tmail-backend/imap-extensions/src/main/java/com/linagora/tmail/imap/TMailCrossDomainIMAPModule.java
@@ -1,0 +1,15 @@
+package com.linagora.tmail.imap;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+import org.apache.james.imap.main.PathConverter;
+import org.apache.james.imap.processor.NamespaceSupplier;
+
+public class TMailCrossDomainIMAPModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(NamespaceSupplier.class).to(TMailNamespaceSupplier.class).in(Scopes.SINGLETON);
+        bind(PathConverter.Factory.class).to(TMailCrossDomainPathConverter.Factory.class).in(Scopes.SINGLETON);
+    }
+}

--- a/tmail-backend/imap-extensions/src/main/java/com/linagora/tmail/imap/TMailCrossDomainPathConverter.java
+++ b/tmail-backend/imap-extensions/src/main/java/com/linagora/tmail/imap/TMailCrossDomainPathConverter.java
@@ -1,0 +1,82 @@
+package com.linagora.tmail.imap;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+import com.linagora.tmail.team.TeamMailbox;
+import com.linagora.tmail.team.TeamMailboxNameSpace;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.james.core.Domain;
+import org.apache.james.core.Username;
+import org.apache.james.imap.api.display.ModifiedUtf7;
+import org.apache.james.imap.api.process.ImapSession;
+import org.apache.james.imap.main.PathConverter;
+import org.apache.james.mailbox.MailboxSession;
+import org.apache.james.mailbox.model.MailboxPath;
+import org.apache.james.mailbox.model.search.MailboxQuery;
+import org.apache.james.mailbox.model.search.PrefixedRegex;
+import org.apache.james.mailbox.model.search.Wildcard;
+
+import java.util.List;
+import java.util.Optional;
+
+public class TMailCrossDomainPathConverter extends TMailPathConverter implements PathConverter {
+
+    public static class Factory implements PathConverter.Factory {
+        public TMailCrossDomainPathConverter forSession(ImapSession session) {
+            return new TMailCrossDomainPathConverter(session.getMailboxSession());
+        }
+
+        public TMailCrossDomainPathConverter forSession(MailboxSession session) {
+            return new TMailCrossDomainPathConverter(session);
+        }
+    }
+
+    private TMailCrossDomainPathConverter(MailboxSession mailboxSession) {
+        super(mailboxSession);
+    }
+
+    public Optional<String> mailboxName(boolean relative, MailboxPath path, MailboxSession session) {
+        if (path.getNamespace().equalsIgnoreCase(TeamMailboxNameSpace.TEAM_MAILBOX_NAMESPACE())) {
+            // FIXME: hacky implementation
+            // Convert local path like MailboxPath(#Teammailbox, team-mailbox@<domain>, <teamXXX>/<folder>)
+            // to external representation like #TeamMailbox/<teamXXX>@<domain>/<folder>
+            List<String> mailboxNameParts = Splitter.on(session.getPathDelimiter()).splitToList(path.getName());
+            String rest = Joiner.on(mailboxSession.getPathDelimiter()).join(Iterables.skip(mailboxNameParts, 1));
+            if (!rest.isEmpty()) {
+                rest = mailboxSession.getPathDelimiter() + rest;
+            }
+            Optional<String> res = Optional.of(path.getNamespace() + session.getPathDelimiter() + mailboxNameParts.getFirst()
+                    + "@" + path.getUser().getDomainPart().map(Domain::asString).orElse("local").replace(String.valueOf(session.getPathDelimiter()), "__")
+                    + rest);
+            return res;
+        } else {
+            return defaultpathConverter.mailboxName(relative, path, session);
+        }
+    }
+
+    protected MailboxPath getTeamMailboxPath(String absolutePath) {
+        // FIXME: hacky implementation
+        // Convert absolute path like #TeamMailbox/<teamXXX>@<domain>/<folder> to local representation
+        // MailboxPath(#Teammailbox, team-mailbox@<domain>, <teamXXX>/<folder>)
+
+        List<String> mailboxPathParts = Splitter.on(mailboxSession.getPathDelimiter()).splitToList(absolutePath);
+        String mailboxName = Joiner.on(mailboxSession.getPathDelimiter()).join(Iterables.skip(mailboxPathParts, 1));
+        List<String> mailboxNameParts = Splitter.on("@").splitToList(mailboxName);
+        if (mailboxNameParts.size() < 2) {
+            return new MailboxPath(TeamMailboxNameSpace.TEAM_MAILBOX_NAMESPACE(), null, mailboxNameParts.getFirst());
+        }
+
+        List<String> mailboxNameParts2 = Splitter.on(mailboxSession.getPathDelimiter()).splitToList(mailboxNameParts.get(1));
+        String rest = Joiner.on(mailboxSession.getPathDelimiter()).join(Iterables.skip(mailboxNameParts2, 1));
+        if (!rest.isEmpty()) {
+            rest = mailboxSession.getPathDelimiter() + rest;
+        }
+        MailboxPath res = new MailboxPath(TeamMailboxNameSpace.TEAM_MAILBOX_NAMESPACE(), teamMailboxUsername(mailboxNameParts2.getFirst().replace("__", String.valueOf(mailboxSession.getPathDelimiter()))), mailboxNameParts.getFirst() + rest);
+        return res;
+    }
+
+    protected Username teamMailboxUsername(String domain) {
+        return Username.from(TeamMailbox.TEAM_MAILBOX_LOCAL_PART(), Optional.of(domain));
+    }
+}

--- a/tmail-backend/imap-extensions/src/main/java/com/linagora/tmail/imap/TMailPathConverter.java
+++ b/tmail-backend/imap-extensions/src/main/java/com/linagora/tmail/imap/TMailPathConverter.java
@@ -50,8 +50,20 @@ public class TMailPathConverter implements PathConverter {
     }
 
     public Optional<String> mailboxName(boolean relative, MailboxPath path, MailboxSession session) {
+
         if (path.getNamespace().equalsIgnoreCase(TeamMailboxNameSpace.TEAM_MAILBOX_NAMESPACE())) {
-            return Optional.of(path.getNamespace() + session.getPathDelimiter() + path.getName());
+            // FIXME: hacky implementation
+            // Convert local path like MailboxPath(#Teammailbox, team-mailbox@<domain>, <teamXXX>/<folder>)
+            // to external representation like #TeamMailbox/<teamXXX>@<domain>/<folder>
+            List<String> mailboxNameParts = Splitter.on(session.getPathDelimiter()).splitToList(path.getName());
+            String rest = Joiner.on(mailboxSession.getPathDelimiter()).join(Iterables.skip(mailboxNameParts, 1));
+            if (!rest.isEmpty()) {
+                rest = mailboxSession.getPathDelimiter() + rest;
+            }
+            Optional<String> res = Optional.of(path.getNamespace() + session.getPathDelimiter() + mailboxNameParts.getFirst()
+                    + "@" + path.getUser().getDomainPart().map(Domain::asString).orElse("local").replace(String.valueOf(session.getPathDelimiter()), "__")
+                    + rest);
+            return res;
         } else {
             return defaultpathConverter.mailboxName(relative, path, session);
         }
@@ -93,12 +105,27 @@ public class TMailPathConverter implements PathConverter {
     }
 
     private MailboxPath getTeamMailboxPath(String absolutePath) {
+        // FIXME: hacky implementation
+        // Convert absolute path like #TeamMailbox/<teamXXX>@<domain>/<folder> to local representation
+        // MailboxPath(#Teammailbox, team-mailbox@<domain>, <teamXXX>/<folder>)
+
         List<String> mailboxPathParts = Splitter.on(mailboxSession.getPathDelimiter()).splitToList(absolutePath);
         String mailboxName = Joiner.on(mailboxSession.getPathDelimiter()).join(Iterables.skip(mailboxPathParts, 1));
-        return new MailboxPath(TeamMailboxNameSpace.TEAM_MAILBOX_NAMESPACE(), teamMailboxUsername(mailboxSession), mailboxName);
+        List<String> mailboxNameParts = Splitter.on("@").splitToList(mailboxName);
+        if (mailboxNameParts.size() < 2) {
+            return new MailboxPath(TeamMailboxNameSpace.TEAM_MAILBOX_NAMESPACE(), null, mailboxNameParts.getFirst());
+        }
+
+        List<String> mailboxNameParts2 = Splitter.on(mailboxSession.getPathDelimiter()).splitToList(mailboxNameParts.get(1));
+        String rest = Joiner.on(mailboxSession.getPathDelimiter()).join(Iterables.skip(mailboxNameParts2, 1));
+        if (!rest.isEmpty()) {
+            rest = mailboxSession.getPathDelimiter() + rest;
+        }
+        MailboxPath res = new MailboxPath(TeamMailboxNameSpace.TEAM_MAILBOX_NAMESPACE(), teamMailboxUsername(mailboxNameParts2.getFirst().replace("__", String.valueOf(mailboxSession.getPathDelimiter()))), mailboxNameParts.getFirst() + rest);
+        return res;
     }
 
-    private Username teamMailboxUsername(MailboxSession mailboxSession) {
-        return Username.from(TeamMailbox.TEAM_MAILBOX_LOCAL_PART(), mailboxSession.getUser().getDomainPart().map(Domain::asString));
+    private Username teamMailboxUsername(String domain) {
+        return Username.from(TeamMailbox.TEAM_MAILBOX_LOCAL_PART(), Optional.of(domain));
     }
 }

--- a/tmail-backend/imap-extensions/src/main/java/com/linagora/tmail/imap/TMailPathConverter.java
+++ b/tmail-backend/imap-extensions/src/main/java/com/linagora/tmail/imap/TMailPathConverter.java
@@ -33,10 +33,10 @@ public class TMailPathConverter implements PathConverter {
         }
     }
 
-    private final MailboxSession mailboxSession;
-    private final PathConverter defaultpathConverter;
+    protected final MailboxSession mailboxSession;
+    protected final PathConverter defaultpathConverter;
 
-    private TMailPathConverter(MailboxSession mailboxSession) {
+    protected TMailPathConverter(MailboxSession mailboxSession) {
         this.mailboxSession = mailboxSession;
         this.defaultpathConverter = PathConverter.Factory.DEFAULT.forSession(mailboxSession);
     }
@@ -50,20 +50,8 @@ public class TMailPathConverter implements PathConverter {
     }
 
     public Optional<String> mailboxName(boolean relative, MailboxPath path, MailboxSession session) {
-
         if (path.getNamespace().equalsIgnoreCase(TeamMailboxNameSpace.TEAM_MAILBOX_NAMESPACE())) {
-            // FIXME: hacky implementation
-            // Convert local path like MailboxPath(#Teammailbox, team-mailbox@<domain>, <teamXXX>/<folder>)
-            // to external representation like #TeamMailbox/<teamXXX>@<domain>/<folder>
-            List<String> mailboxNameParts = Splitter.on(session.getPathDelimiter()).splitToList(path.getName());
-            String rest = Joiner.on(mailboxSession.getPathDelimiter()).join(Iterables.skip(mailboxNameParts, 1));
-            if (!rest.isEmpty()) {
-                rest = mailboxSession.getPathDelimiter() + rest;
-            }
-            Optional<String> res = Optional.of(path.getNamespace() + session.getPathDelimiter() + mailboxNameParts.getFirst()
-                    + "@" + path.getUser().getDomainPart().map(Domain::asString).orElse("local").replace(String.valueOf(session.getPathDelimiter()), "__")
-                    + rest);
-            return res;
+            return Optional.of(path.getNamespace() + session.getPathDelimiter() + path.getName());
         } else {
             return defaultpathConverter.mailboxName(relative, path, session);
         }
@@ -104,28 +92,13 @@ public class TMailPathConverter implements PathConverter {
         return defaultpathConverter.mailboxQuery(finalReferencename, mailboxName, session);
     }
 
-    private MailboxPath getTeamMailboxPath(String absolutePath) {
-        // FIXME: hacky implementation
-        // Convert absolute path like #TeamMailbox/<teamXXX>@<domain>/<folder> to local representation
-        // MailboxPath(#Teammailbox, team-mailbox@<domain>, <teamXXX>/<folder>)
-
+    protected MailboxPath getTeamMailboxPath(String absolutePath) {
         List<String> mailboxPathParts = Splitter.on(mailboxSession.getPathDelimiter()).splitToList(absolutePath);
         String mailboxName = Joiner.on(mailboxSession.getPathDelimiter()).join(Iterables.skip(mailboxPathParts, 1));
-        List<String> mailboxNameParts = Splitter.on("@").splitToList(mailboxName);
-        if (mailboxNameParts.size() < 2) {
-            return new MailboxPath(TeamMailboxNameSpace.TEAM_MAILBOX_NAMESPACE(), null, mailboxNameParts.getFirst());
-        }
-
-        List<String> mailboxNameParts2 = Splitter.on(mailboxSession.getPathDelimiter()).splitToList(mailboxNameParts.get(1));
-        String rest = Joiner.on(mailboxSession.getPathDelimiter()).join(Iterables.skip(mailboxNameParts2, 1));
-        if (!rest.isEmpty()) {
-            rest = mailboxSession.getPathDelimiter() + rest;
-        }
-        MailboxPath res = new MailboxPath(TeamMailboxNameSpace.TEAM_MAILBOX_NAMESPACE(), teamMailboxUsername(mailboxNameParts2.getFirst().replace("__", String.valueOf(mailboxSession.getPathDelimiter()))), mailboxNameParts.getFirst() + rest);
-        return res;
+        return new MailboxPath(TeamMailboxNameSpace.TEAM_MAILBOX_NAMESPACE(), teamMailboxUsername(mailboxSession), mailboxName);
     }
 
-    private Username teamMailboxUsername(String domain) {
-        return Username.from(TeamMailbox.TEAM_MAILBOX_LOCAL_PART(), Optional.of(domain));
+    protected Username teamMailboxUsername(MailboxSession mailboxSession) {
+        return Username.from(TeamMailbox.TEAM_MAILBOX_LOCAL_PART(), mailboxSession.getUser().getDomainPart().map(Domain::asString));
     }
 }

--- a/tmail-backend/mailbox/team-mailboxes/src/main/scala/com/linagora/tmail/team/TeamMailbox.scala
+++ b/tmail-backend/mailbox/team-mailboxes/src/main/scala/com/linagora/tmail/team/TeamMailbox.scala
@@ -101,7 +101,7 @@ object TeamMailbox {
   def from(mailboxPath: MailboxPath): Option[TeamMailbox] = mailboxPath.getNamespace match {
     case TEAM_MAILBOX_NAMESPACE =>
       for {
-        name <- TeamMailboxName.validate(mailboxPath.getHierarchyLevels('.').get(0).getName())
+        name <- TeamMailboxName.validate(mailboxPath.getHierarchyLevels(MailboxConstants.DEFAULT_DELIMITER).get(0).getName())
           .map(nameValue => TeamMailboxName(nameValue))
           .toOption
         domain <- mailboxPath.getUser.getDomainPart.toScala
@@ -133,11 +133,11 @@ case class TeamMailbox(domain: Domain, mailboxName: TeamMailboxName) {
 
   def mailboxPath: MailboxPath = new MailboxPath(TEAM_MAILBOX_NAMESPACE, Username.fromLocalPartWithDomain(TEAM_MAILBOX_LOCAL_PART, domain), mailboxName.value)
 
-  def mailboxPath(subPath : String): MailboxPath = new MailboxPath(TEAM_MAILBOX_NAMESPACE, Username.fromLocalPartWithDomain(TEAM_MAILBOX_LOCAL_PART, domain), s"${mailboxName.value}.$subPath")
+  def mailboxPath(subPath : String): MailboxPath = new MailboxPath(TEAM_MAILBOX_NAMESPACE, Username.fromLocalPartWithDomain(TEAM_MAILBOX_LOCAL_PART, domain), s"${mailboxName.value}${MailboxConstants.DEFAULT_DELIMITER}$subPath")
 
-  def inboxPath: MailboxPath = new MailboxPath(TEAM_MAILBOX_NAMESPACE, Username.fromLocalPartWithDomain(TEAM_MAILBOX_LOCAL_PART, domain), s"${mailboxName.value}.${MailboxConstants.INBOX}")
+  def inboxPath: MailboxPath = new MailboxPath(TEAM_MAILBOX_NAMESPACE, Username.fromLocalPartWithDomain(TEAM_MAILBOX_LOCAL_PART, domain), s"${mailboxName.value}${MailboxConstants.DEFAULT_DELIMITER}${MailboxConstants.INBOX}")
 
-  def sentPath: MailboxPath = new MailboxPath(TEAM_MAILBOX_NAMESPACE, Username.fromLocalPartWithDomain(TEAM_MAILBOX_LOCAL_PART, domain), s"${mailboxName.value}.Sent")
+  def sentPath: MailboxPath = new MailboxPath(TEAM_MAILBOX_NAMESPACE, Username.fromLocalPartWithDomain(TEAM_MAILBOX_LOCAL_PART, domain), s"${mailboxName.value}${MailboxConstants.DEFAULT_DELIMITER}Sent")
 
   def defaultMailboxPaths: Seq[MailboxPath] = Seq(
     mailboxPath,


### PR DESCRIPTION
Allow adding users to TeamMailboxes of different domains and show full mail address in mail client.
Whether full addresses are shown can be toggled via configuration

![image](https://github.com/user-attachments/assets/8e6ce522-e144-429e-a830-5bb19eb0e8e6)